### PR TITLE
feat: added hexCodes for wsl-powershell Home and End keys

### DIFF
--- a/input.go
+++ b/input.go
@@ -163,6 +163,8 @@ var hexCodes = map[string]keys.Key{
 	"1b4f42": {Code: keys.Down, AltPressed: false},
 	"1b4f43": {Code: keys.Right, AltPressed: false},
 	"1b4f44": {Code: keys.Left, AltPressed: false},
+	"1b5b46": {Code: keys.End, AltPressed: false},
+	"1b5b48": {Code: keys.Home, AltPressed: false},
 }
 
 func getKeyPress() (keys.Key, error) {


### PR DESCRIPTION
This resolves an issue I filed (#9).  Home and End keys now have a hexCode in the input.go file that handles them for Powershell running WSL.  I have not tested this in any other scenarios.